### PR TITLE
fix: MetaData is Optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "throttled_xrp_rpc"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Aiden McClelland <aiden.k.mcclelland@gmail.com>", "Drew Ansbacher <drew.ansbacher@gmail.com>"]
 repository = "https://github.com/DR-BoneZ/throttled-xrp-rpc-rs"
 homepage = "https://github.com/DR-BoneZ/throttled-xrp-rpc-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ pub struct TransactionInfo {
     pub TransactionType: String,
     pub TxnSignature: Option<String>,
     pub hash: String,
-    pub metaData: MetaTxInfo,
+    pub metaData: Option<MetaTxInfo>,
     pub validated: Option<bool>, //option of a bool???
 }
 


### PR DESCRIPTION
We got an error message from the server that indacted that this is an optional type.